### PR TITLE
Exclude some packages when installing on unraid 7

### DIFF
--- a/unRAID6-Sanoid.plg
+++ b/unRAID6-Sanoid.plg
@@ -4,7 +4,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name "unRAID6-Sanoid">
 <!ENTITY author "Steini1984">
-<!ENTITY version "2.2.0b">
+<!ENTITY version "2.2.0c">
 <!ENTITY repo "https://raw.githubusercontent.com/&author;/unRAID6-Sainoid/master">
   <!ENTITY pluginURL "&repo;/&name;.plg">
   <!ENTITY plugin    "/boot/config/plugins/&name;">
@@ -18,6 +18,9 @@
 >
 
 <CHANGES>
+
+###2024.07.11
+Do not install mbuffer and perl package on unraid 7
 
 ###2024.04.30
 New version of mbuffer fixed - mbuffer-20240107-x86_64-1_SBo.tgz (compiled by @SoerenS from https://slackbuilds.org/repository/15.0/system/mbuffer/)
@@ -41,7 +44,7 @@ Initial release Sanoid 2.0.3
 
 <FILE Name="&emhttp;/README.md">
 <INLINE>
-Sanoid for unRAID 6
+Sanoid for unRAID 6/7
 
 Sanoid is a policy-driven snapshot management tool for ZFS filesystems.
 
@@ -60,14 +63,23 @@ iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1I
 
 PACKAGES="
 lzop-1.04-x86_64-2_slonly.txz
-mbuffer-20240107-x86_64-1_SBo.tgz
-perl-5.34.0-x86_64-2_slack15.0.txz
 perl-Capture-Tiny-0.48-x86_64-1ponce.txz
 perl-Config-IniFiles-2.82-x86_64-3_slonly.txz
 perl-Exporter-Tiny-1.000000-x86_64-1ponce.txz
 perl-List-MoreUtils-0.425-x86_64-2_slonly.txz
 sanoid.2.2.0.x86_64.tgz
 "
+
+# Append packages required for unraid 6
+source /etc/unraid-version
+version=${version:0:2}
+if [[ $((${version/./}*1)) -lt 7 ]]; then
+  PACKAGES="
+mbuffer-20240107-x86_64-1_SBo.tgz
+perl-5.34.0-x86_64-2_slack15.0.txz
+${PACKAGES}
+"
+fi
 
 #Download and install a package
 download_install() {


### PR DESCRIPTION
Do not install mbuffer and perl packages on unraid 7